### PR TITLE
fix: Avoid writing lnInst for LLN0 references in FCDA (closes #21)

### DIFF
--- a/editors/dataset/foundation.spec.ts
+++ b/editors/dataset/foundation.spec.ts
@@ -104,6 +104,13 @@ describe('Utility functions for FCDA element', () => {
       expect(addFCDAs(dataSet1, paths).length).to.equal(1);
     });
 
+    it('returns FCDA without lnInst for LLN0', () => {
+      const paths = [[lDevice, anyLn1, dO, sDO, dA, bDA1, bDA3]];
+      const insertEdit = addFCDAs(dataSet1, paths);
+      const newFcda = insertEdit[0].node as Element;
+      expect(newFcda.hasAttribute('lnInst')).to.equal(false);
+    });
+
     it('allows multiple FCDA inserts', () => {
       const paths = [
         [lDevice, anyLn, dO, sDO, dA, bDA1, bDA2],

--- a/editors/dataset/foundation.ts
+++ b/editors/dataset/foundation.ts
@@ -8,7 +8,7 @@ function findFcda(
     ldInst: string;
     prefix: string;
     lnClass: string;
-    lnInst: string;
+    lnInst?: string;
     doName: string;
     daName?: string;
     fc: string;
@@ -69,7 +69,7 @@ export function addFCDAs(dataSet: Element, paths: Element[][]): Insert[] {
       ldInst,
       prefix,
       lnClass,
-      lnInst,
+      ...(lnClass !== 'LLN0' && { lnInst }),
       doName,
       daName,
       fc,


### PR DESCRIPTION
Closes #21.

I would be most grateful for a review.